### PR TITLE
More flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM golang:1.21-alpine AS build
+
+RUN go install github.com/txn2/txeh/txeh@master
+
 # hadolint ignore=DL3007
 FROM ghcr.io/spacelift-io/runner-terraform:latest AS spacelift
 
@@ -5,6 +9,9 @@ USER root
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache tailscale
+
+COPY --from=build --chown=root:root /go/bin/txeh /usr/local/bin/
+RUN chmod 4755 /usr/local/bin/txeh
 
 COPY bin/ /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,14 @@ FROM ghcr.io/spacelift-io/runner-terraform:latest AS spacelift
 
 USER root
 
+
 # hadolint ignore=DL3018
 RUN apk add --no-cache tailscale
 
+# Let tailscale/d use default socket location
+RUN mkdir -p /var/run/tailscale && chown spacelift:spacelift /var/run/tailscale
+
+# Lets us easily add entries to /etc/hosts if we wish
 COPY --from=build --chown=root:root /go/bin/txeh /usr/local/bin/
 RUN chmod 4755 /usr/local/bin/txeh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-FROM golang:1.21-alpine AS build
-
-RUN go install github.com/txn2/txeh/txeh@master
-
 # hadolint ignore=DL3007
 FROM ghcr.io/spacelift-io/runner-terraform:latest AS spacelift
 
 USER root
-
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache tailscale
 
 # Let tailscale/d use default socket location
 RUN mkdir -p /var/run/tailscale && chown spacelift:spacelift /var/run/tailscale
-
-# Lets us easily add entries to /etc/hosts if we wish
-COPY --from=build --chown=root:root /go/bin/txeh /usr/local/bin/
-RUN chmod 4755 /usr/local/bin/txeh
 
 COPY bin/ /usr/local/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: docker-build
 docker-build:
-	docker build \
+	DOCKER_BUILDKIT=1 docker build \
 	--tag ghcr.io/caius/spacelift-tailscale:dev \
 	.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ your-stage-id:
   # …
 ```
 
+## Configuration
+
+Configuration is via various envariables in the Spacelift runner container, inspired by tailscale's `containerboot` binary:
+
+- `TS_AUTH_KEY` - Tailscale auth key (Suggest creating ephemeral & tagged key)
+- `TS_TAILSCALED_EXTRA_ARGS` - Extra arguments to pass to `tailscaled`. eg, `--socks5-server=localhost:1080`
+- `TS_TAILSCALE_ARGS` - Extra arguments to pass to `tailscale up`. eg, `--ssh` for debugging
+
 ## Context
 
 Spacelift runs terraform (or other tooling) in containers, and controls the commands that run therein. They operate in phases, and don't detect the "end" of a phase until all processes in the container have exited. It appears each phase _can_ be executed in a different container, but with the same workspace directory/environment variables copied between containers.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ your-stage-id:
     - "spacetail down"
 ```
 
+Due to having to run tailscale in userspace-networking, we need to use it as a HTTP Proxy to talk to things on the Tailnet. Happily, terraform providers usually lean on Go's `net/http` package which picks up `HTTP_PROXY` from the environment and Just Works™. (If you find a provider that doesn't work, I'd suggest reporting upstream to them!)
+
+You'll somehow need to inject that into the environment of the phase, the easiest way is to include it in your `config.yml` as well:
+
+```yaml
+your-stage-id:
+  # …
+  environment:
+    HTTP_PROXY: "http://localhost:8080"
+    http_proxy: "http://localhost:8080"
+  # …
+```
+
 ## Context
 
 Spacelift runs terraform (or other tooling) in containers, and controls the commands that run therein. They operate in phases, and don't detect the "end" of a phase until all processes in the container have exited. It appears each phase _can_ be executed in a different container, but with the same workspace directory/environment variables copied between containers.

--- a/README.md
+++ b/README.md
@@ -50,21 +50,6 @@ your-stage-id:
   # …
 ```
 
-The other, more complex, route is to inject the Tailscale IP for a given host you want to correspond with into the `/etc/hosts` file. This will need to be called before every phase that wants to talk to it, and you'll need to know ahead of time what you want to connect to. Anything that can look up the hostname in `/etc/hosts` will be able to connect to it however.
-
-We use a tool called `txeh` to manage `/etc/hosts`, it's already in the image and has suid bit set so it has permissions to edit `/etc/hosts` even though we're running as spacelift user.
-
-```yaml
-your-stage-id:
-  # …
-  before_plan:
-    - "spacetail up"
-    # Repeat for all your tailscale hosts you want to talk to
-    - "/usr/local/bin/txeh $(tailscale --socket /mnt/workspace/tailscaled.sock ip -4 server1) server1"
-  after_plan:
-    - "spacetail down"
-```
-
 ## Configuration
 
 Configuration is via various envariables in the Spacelift runner container, inspired by tailscale's `containerboot` binary:

--- a/README.md
+++ b/README.md
@@ -50,14 +50,17 @@ your-stage-id:
   # …
 ```
 
-The other, more complex, route is to inject the Tailscale IP for a given host you want to correspond with into the `/etc/hosts` file. This will need to be called before every phase that wants to talk to it. Anything that can look up the hostname in `/etc/hosts` will be able to connect to it however.
+The other, more complex, route is to inject the Tailscale IP for a given host you want to correspond with into the `/etc/hosts` file. This will need to be called before every phase that wants to talk to it, and you'll need to know ahead of time what you want to connect to. Anything that can look up the hostname in `/etc/hosts` will be able to connect to it however.
+
+We use a tool called `txeh` to manage `/etc/hosts`, it's already in the image and has suid bit set so it has permissions to edit `/etc/hosts` even though we're running as spacelift user.
 
 ```yaml
 your-stage-id:
   # …
   before_plan:
     - "spacetail up"
-    - "echo \"$(tailscale --socket /mnt/workspace/tailscaled.sock ip -4 server1)\tserver1\" >> /etc/hosts"
+    # Repeat for all your tailscale hosts you want to talk to
+    - "/usr/local/bin/txeh $(tailscale --socket /mnt/workspace/tailscaled.sock ip -4 server1) server1"
   after_plan:
     - "spacetail down"
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Configuration is via various envariables in the Spacelift runner container, insp
 
 - `TS_AUTH_KEY` - Tailscale auth key (Suggest creating ephemeral & tagged key)
 - `TS_TAILSCALED_EXTRA_ARGS` - Extra arguments to pass to `tailscaled`. eg, `--socks5-server=localhost:1080`
-- `TS_TAILSCALE_ARGS` - Extra arguments to pass to `tailscale up`. eg, `--ssh` for debugging
+- `TS_EXTRA_ARGS` - Extra arguments to pass to `tailscale up`. eg, `--ssh` for debugging
 
 ## Context
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ your-stage-id:
 
 Due to running tailscaled with userspace networking, we don't get MagicDNS wiring up requests for us. Packets are routed to the correct IPs without us having to do anything however, so we just need to solve the DNS issue.
 
-The suggested solution from Tailscale documentation is to use either a SOCKS5 or HTTP Proxy. We run a HTTP Proxy on `localhost:8080` in the container by default, so that's likely the easiest way to go. This requires `http_proxy` setting in the environment, and your Terraform provider able to make use of it. (Anything using Go's `net/http` library should be able to use it automatically.)
+The suggested solution from Tailscale documentation is to use either a SOCKS5 or HTTP Proxy. We run http proxy on `localhost:8080` and socks5 on `localhost:1080` in the container by default, so that's likely the easiest way to go. This requires `http_proxy` setting in the environment, and your Terraform provider able to make use of it. (Anything using Go's `net/http` library should be able to use it automatically.)
 
 You'll somehow need to inject that into the environment of the phase, the easiest way is to include it in your `config.yml` as well:
 

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -41,7 +41,7 @@ fi
 readonly TS_EXTRA_ARGS
 
 if [[ -z ${TS_TAILSCALED_EXTRA_ARGS:-} ]]; then
-  TS_TAILSCALED_EXTRA_ARGS="--outbound-http-proxy-listen=localhost:8080"
+  TS_TAILSCALED_EXTRA_ARGS="--socks5-server=localhost:1080 --outbound-http-proxy-listen=localhost:8080"
 fi
 readonly TS_TAILSCALED_EXTRA_ARGS
 

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -36,7 +36,7 @@ ACTION="${1:-}"
 readonly ACTION
 
 if [[ -z ${TS_EXTRA_ARGS:-} ]]; then
-  TS_EXTRA_ARGS="--accept-dns=false"
+  TS_EXTRA_ARGS="--accept-dns=false --hostname=spacelift-$(hostname)"
 fi
 readonly TS_EXTRA_ARGS
 

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -35,10 +35,10 @@ fi
 ACTION="${1:-}"
 readonly ACTION
 
-if [[ -z ${TS_TAILSCALE_EXTRA_ARGS:-} ]]; then
-  TS_TAILSCALE_EXTRA_ARGS="--accept-dns=false"
+if [[ -z ${TS_EXTRA_ARGS:-} ]]; then
+  TS_EXTRA_ARGS="--accept-dns=false"
 fi
-readonly TS_TAILSCALE_EXTRA_ARGS
+readonly TS_EXTRA_ARGS
 
 if [[ -z ${TS_TAILSCALED_EXTRA_ARGS:-} ]]; then
   TS_TAILSCALED_EXTRA_ARGS="--outbound-http-proxy-listen=localhost:8080"
@@ -65,7 +65,7 @@ if [[ "${ACTION}" = "up" ]]; then
     # shellcheck disable=SC2086
     tailscale --socket "${TF_VAR_spacelift_workspace_root}/tailscaled.sock" up \
     --authkey "${TS_AUTH_KEY}" \
-    ${TS_TAILSCALE_EXTRA_ARGS}
+    ${TS_EXTRA_ARGS}
   echo "spacetail: Tailscale up"
 elif [[ "${ACTION}" = "down" ]]; then
   echo "spacetail: Shutting tailscale down"

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -53,7 +53,6 @@ if [[ "${ACTION}" = "up" ]]; then
 
   # shellcheck disable=SC2086
   nohup tailscaled \
-    --socket "${TF_VAR_spacelift_workspace_root}/tailscaled.sock" \
     --state=mem: --statedir="${TF_VAR_spacelift_workspace_root}/tailscale-state" \
     --tun=userspace-networking \
     ${TS_TAILSCALED_EXTRA_ARGS} \
@@ -63,7 +62,7 @@ if [[ "${ACTION}" = "up" ]]; then
 
     # FIXME: remove --ssh once we're done debugging
     # shellcheck disable=SC2086
-    tailscale --socket "${TF_VAR_spacelift_workspace_root}/tailscaled.sock" up \
+    tailscale up \
     --authkey "${TS_AUTH_KEY}" \
     ${TS_EXTRA_ARGS}
   echo "spacetail: Tailscale up"

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -35,26 +35,37 @@ fi
 ACTION="${1:-}"
 readonly ACTION
 
+if [[ -z ${TS_TAILSCALE_EXTRA_ARGS:-} ]]; then
+  TS_TAILSCALE_EXTRA_ARGS="--accept-dns=false"
+fi
+readonly TS_TAILSCALE_EXTRA_ARGS
+
+if [[ -z ${TS_TAILSCALED_EXTRA_ARGS:-} ]]; then
+  TS_TAILSCALED_EXTRA_ARGS="--outbound-http-proxy-listen=localhost:8080"
+fi
+readonly TS_TAILSCALED_EXTRA_ARGS
+
 if [[ "${ACTION}" = "up" ]]; then
   echo "spacetail: Bringing tailscale up"
 
   # With massive thanks to containerboot
   # https://github.com/tailscale/tailscale/blob/main/cmd/containerboot/main.go
 
+  # shellcheck disable=SC2086
   nohup tailscaled \
     --socket "${TF_VAR_spacelift_workspace_root}/tailscaled.sock" \
     --state=mem: --statedir="${TF_VAR_spacelift_workspace_root}/tailscale-state" \
     --tun=userspace-networking \
-    --outbound-http-proxy-listen=localhost:8080 \
+    ${TS_TAILSCALED_EXTRA_ARGS} \
     >> "${TF_VAR_spacelift_workspace_root}/tailscaled.log" &
 
     sleep 1 # FIXME: grep tailscaled output somehow instead of this?
 
     # FIXME: remove --ssh once we're done debugging
+    # shellcheck disable=SC2086
     tailscale --socket "${TF_VAR_spacelift_workspace_root}/tailscaled.sock" up \
     --authkey "${TS_AUTH_KEY}" \
-    --accept-dns=false \
-    --ssh
+    ${TS_TAILSCALE_EXTRA_ARGS}
   echo "spacetail: Tailscale up"
 elif [[ "${ACTION}" = "down" ]]; then
   echo "spacetail: Shutting tailscale down"

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -71,14 +71,6 @@ elif [[ "${ACTION}" = "down" ]]; then
   # Stopping tailscaled brings the ephemeral node down cleanly
   pkill tailscaled
   echo "spacetail: Tailscale down"
-elif [[ "${ACTION}" = "add-hosts" ]]; then
-  for name in "$@"; do
-    if [[ "${name}" = "add-hosts" ]]; then
-      continue
-    fi
-    echo "spacetail: Adding host ${name} to tailscale"
-    /usr/local/bin/txeh add "$(tailscale ip --1 "${name}")" "${name}"
-  done
 else
   echo "spacetail: Unknown action ${ACTION}"
   usage

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -71,6 +71,14 @@ elif [[ "${ACTION}" = "down" ]]; then
   # Stopping tailscaled brings the ephemeral node down cleanly
   pkill tailscaled
   echo "spacetail: Tailscale down"
+elif [[ "${ACTION}" = "add-hosts" ]]; then
+  for name in "$@"; do
+    if [[ "${name}" = "add-hosts" ]]; then
+      continue
+    fi
+    echo "spacetail: Adding host ${name} to tailscale"
+    /usr/local/bin/txeh add "$(tailscale ip --1 "${name}")" "${name}"
+  done
 else
   echo "spacetail: Unknown action ${ACTION}"
   usage


### PR DESCRIPTION
## What?

- [x] Document using `HTTP_PROXY` with terraform
- [x] Allow injecting tailscaled arguments via `TS_TAILSCALED_EXTRA_ARGS`
- [x] Allow injecting tailscale arguments via `TS_EXTRA_ARGS`
- [ ] ~Install [txeh](https://github.com/txn2/txeh) into the image for managing `/etc/hosts`~
- [ ] ~Document two approaches to using the tailnet~
- [x] Prefix container hostname with `spacelift-` in tailscale

## Why?

Flexibility, and finishing off the instructions for people to make use of this.

Can't find a way to edit `/etc/hosts` in the image as root, which stops us going down the route of updating it with ip/name from `tailscale status` to get basic routing/lookup working in the image.