### PR TITLE
Tidyup output in plans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ USER root
 # hadolint ignore=DL3018
 RUN apk add --no-cache tailscale
 
-# Let tailscale/d use default socket location
-RUN mkdir -p /var/run/tailscale && chown spacelift:spacelift /var/run/tailscale
-
 COPY bin/ /usr/local/bin/
+
+# Let tailscale/d use default socket location
+RUN mkdir -p /home/spacelift/.local/share/tailscale /var/run/tailscale && chown spacelift:spacelift /home/spacelift/.local/share/tailscale /var/run/tailscale
 
 USER spacelift

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -58,7 +58,6 @@ if [[ "${ACTION}" = "up" ]]; then
 
     sleep 1 # FIXME: grep tailscaled output somehow instead of this?
 
-    # FIXME: remove --ssh once we're done debugging
     # shellcheck disable=SC2086
     tailscale up \
     --authkey "${TS_AUTH_KEY}" \

--- a/bin/spacetail
+++ b/bin/spacetail
@@ -54,7 +54,7 @@ if [[ "${ACTION}" = "up" ]]; then
   nohup tailscaled \
     --state=mem: --statedir="${TF_VAR_spacelift_workspace_root}/tailscale-state" \
     --tun=userspace-networking \
-    ${TS_TAILSCALED_EXTRA_ARGS} &
+    ${TS_TAILSCALED_EXTRA_ARGS} 2> /home/spacelift/tailscaled.log &
 
     sleep 1 # FIXME: grep tailscaled output somehow instead of this?
 
@@ -64,7 +64,7 @@ if [[ "${ACTION}" = "up" ]]; then
     ${TS_EXTRA_ARGS}
   echo "spacetail: Tailscale up"
 elif [[ "${ACTION}" = "down" ]]; then
-  echo "spacetail: Shutting tailscale down"
+  echo "spacetail: Taking tailscale down"
   # Stopping tailscaled brings the ephemeral node down cleanly
   pkill tailscaled
   echo "spacetail: Tailscale down"


### PR DESCRIPTION
## What?

- [x] Redirect `tailscaled` output to file

## Why?

Having it show up in the terraform output is very annoying, and not really needed so let's shove it in a file instead. If you need to debug things not working, you'll want to add something to your stack config like:

```
trap 'cat /home/spacelift/tailscaled.log' EXIT
```

Fixes #7 
